### PR TITLE
Update default LibTorch options in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ option(GUROBI_ROOT "Path to Gurobi installation" "")
 set(GUROBI_ROOT $ENV{HOME}/.local/lib/gurobi1103/linux64)
 
 # LibTorch Configuration
-option(CDDP_CPP_TORCH "Whether to use LibTorch" ON)
-option(CDDP_CPP_TORCH_GPU "Whether to use GPU support in LibTorch" ON)
+option(CDDP_CPP_TORCH "Whether to use LibTorch" OFF)
+option(CDDP_CPP_TORCH_GPU "Whether to use GPU support in LibTorch" OFF)
 set(LIBTORCH_DIR $ENV{HOME}/.local/lib/libtorch CACHE PATH "Path to local LibTorch installation") # FIXME: Change this to your local LibTorch installation directory
 
 # Python Configuration


### PR DESCRIPTION
Change the default options for using LibTorch and GPU support to OFF in the CMake configuration.