### PR TITLE
Update examples to new modular solver API

### DIFF
--- a/examples/cddp_car_ipddp.cpp
+++ b/examples/cddp_car_ipddp.cpp
@@ -161,37 +161,35 @@ int main() {
     // Create the nonlinear objective for car parking
     auto objective = std::make_unique<cddp::CarParkingObjective>(goal_state, timestep);
 
-    // Create CDDP solver for the car model
-    cddp::CDDP cddp_solver(initial_state, goal_state, horizon, timestep);
-    cddp_solver.setDynamicalSystem(std::move(system));
-    cddp_solver.setObjective(std::move(objective));
+    // Set solver options
+    cddp::CDDPOptions options;
+    options.max_iterations = 600;
+    options.verbose = true;  
+    options.tolerance = 1e-7;
+    options.acceptable_tolerance = 1e-4;
+    options.regularization.type = "control";
+    options.regularization.state = 0.0;
+    options.regularization.control = 1e-7;
+    options.debug = false;
+    options.use_ilqr = true;
+    options.enable_parallel = false;
+    options.num_threads = 1;
+    options.msipddp.barrier.mu_initial = 1e-0;
+    options.msipddp.dual_scale = 1e-1;
+    options.msipddp.slack_scale = 1e-2;
+    options.msipddp.segment_length = horizon / 100;
+    options.msipddp.rollout_type = "nonlinear";
+
+    // Create CDDP solver for the car model with new API
+    cddp::CDDP cddp_solver(initial_state, goal_state, horizon, timestep,
+                          std::move(system), std::move(objective), options);
 
     // Define control constraints
     Eigen::VectorXd control_lower_bound(control_dim);
     control_lower_bound << -0.5, -2.0;  // [steering_angle, acceleration]
     Eigen::VectorXd control_upper_bound(control_dim);
     control_upper_bound << 0.5, 2.0;
-    cddp_solver.addConstraint("ControlConstraint", std::make_unique<cddp::ControlConstraint>(control_upper_bound));
-
-    // Set solver options
-    cddp::CDDPOptions options;
-    options.max_iterations = 600;
-    options.verbose = true;  
-    options.cost_tolerance = 1e-7;
-    options.grad_tolerance = 1e-4;
-    options.regularization_type = "control";
-    options.regularization_state = 0.0;
-    options.regularization_control = 1e-7;
-    options.debug = false;
-    options.is_ilqr = true;
-    options.use_parallel = false;
-    options.num_threads = 1;
-    options.barrier_coeff = 1e-0;
-    options.dual_scale = 1e-1;
-    options.slack_scale = 1e-2;
-    options.ms_segment_length = horizon / 100;
-    options.ms_rollout_type = "nonlinear";
-    cddp_solver.setOptions(options);
+    cddp_solver.addPathConstraint("ControlConstraint", std::make_unique<cddp::ControlConstraint>(control_upper_bound));
 
     // Initialize the trajectory with zero controls
     std::vector<Eigen::VectorXd> X(horizon + 1, Eigen::VectorXd::Zero(state_dim));
@@ -200,21 +198,21 @@ int main() {
     for (int i = 0; i < horizon; ++i) {
         U[i](0) = 0.01;
         U[i](1) = 0.01;
-        X[i + 1] = cddp_solver.getSystem().getDiscreteDynamics(X[i], U[i], i * timestep);
+        X[i + 1] = cddp_solver.getDynamicalSystem()->getDiscreteDynamics(X[i], U[i], i * timestep);
     }
     cddp_solver.setInitialTrajectory(X, U);
 
-    // Solve the problem using IPDDP
-    cddp::CDDPSolution solution = cddp_solver.solve("MSIPDDP");
+    // Solve the problem using MSIPDDP
+    cddp::CDDPSolution solution = cddp_solver.solve(cddp::SolverType::MSIPDDP);
 
     // Extract solution trajectories
-    auto X_sol = solution.state_sequence;
-    auto U_sol = solution.control_sequence;
-    auto t_sol = solution.time_sequence;
+    auto X_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("state_trajectory"));
+    auto U_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("control_trajectory"));
+    auto t_sol = std::any_cast<std::vector<double>>(solution.at("time_points"));
 
     // Prepare trajectory data for plotting
     std::vector<double> x_hist, y_hist;
-    for (const auto& state : solution.state_sequence) {
+    for (const auto& state : X_sol) {
         x_hist.push_back(state(0));
         y_hist.push_back(state(1));
     }

--- a/examples/cddp_lti_system.cpp
+++ b/examples/cddp_lti_system.cpp
@@ -92,28 +92,26 @@ int main() {
     std::vector<Eigen::VectorXd> empty_reference_states;
     auto objective = std::make_unique<cddp::QuadraticObjective>(Q, R, Qf, goal_state, empty_reference_states, timestep);
 
-    // Create CDDP solver
-    cddp::CDDP cddp_solver(initial_state, goal_state, horizon, timestep);
-    cddp_solver.setDynamicalSystem(std::move(system));
-    cddp_solver.setObjective(std::move(objective));
+    // Solver options
+    cddp::CDDPOptions options;
+    options.max_iterations = 10;
+    options.verbose = true;
+    options.regularization.type = "control";
+    options.num_threads = 11;
+    options.enable_parallel = true;
+    options.debug = false;
+
+    // Create CDDP solver with new API
+    cddp::CDDP cddp_solver(initial_state, goal_state, horizon, timestep,
+                          std::move(system), std::move(objective), options);
 
     // Control constraints
     Eigen::VectorXd control_lower_bound = -0.6 * Eigen::VectorXd::Ones(control_dim);
     Eigen::VectorXd control_upper_bound = 0.6 * Eigen::VectorXd::Ones(control_dim);
 
-    cddp_solver.addConstraint("ControlBoxConstraint", 
+    cddp_solver.addPathConstraint("ControlBoxConstraint", 
         std::make_unique<cddp::ControlBoxConstraint>(
             control_lower_bound, control_upper_bound));
-
-    // Solver options
-    cddp::CDDPOptions options;
-    options.max_iterations = 10;
-    options.verbose = true;
-    options.regularization_type = "control";
-    options.num_threads = 11;
-    options.use_parallel = true;
-    options.debug = false;
-    cddp_solver.setOptions(options);
 
     // Initialize trajectories
     std::vector<Eigen::VectorXd> X(horizon + 1, Eigen::VectorXd::Zero(state_dim));
@@ -133,11 +131,11 @@ int main() {
     double J = 0.0;
     double cost = 0.0;
     for (size_t t = 0; t < horizon; t++) {
-        cost = cddp_solver.getObjective().running_cost(X[t], U[t], t);
+        cost = cddp_solver.getObjective()->running_cost(X[t], U[t], t);
         J += cost;
-        X[t + 1] = cddp_solver.getSystem().getDiscreteDynamics(X[t], U[t], t * timestep);
+        X[t + 1] = cddp_solver.getDynamicalSystem()->getDiscreteDynamics(X[t], U[t], t * timestep);
     }
-    J += cddp_solver.getObjective().terminal_cost(X.back());
+    J += cddp_solver.getObjective()->terminal_cost(X.back());
     std::cout << "Initial state: " << X[0].transpose() << std::endl;
     std::cout << "Final state: " << X.back().transpose() << std::endl;
     std::cout << "Initial cost: " << J << std::endl;
@@ -145,13 +143,17 @@ int main() {
     cddp_solver.setInitialTrajectory(X, U);
 
     // Solve using the CDDP solver
-    cddp::CDDPSolution solution = cddp_solver.solve();
-    // Alternatively: cddp::CDDPSolution solution = cddp_solver.solveLogCDDP();
+    cddp::CDDPSolution solution = cddp_solver.solve(cddp::SolverType::ASDDP);
+    // Alternatively: cddp::CDDPSolution solution = cddp_solver.solve(cddp::SolverType::LogDDP);
 
     // Extract solution trajectories
-    auto X_sol = solution.state_sequence;
-    auto U_sol = solution.control_sequence;
-    auto t_sol = solution.time_sequence;
+    auto X_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("state_trajectory"));
+    auto U_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("control_trajectory"));
+    auto t_sol = std::any_cast<std::vector<double>>(solution.at("time_points"));
+    auto cost_sequence = std::any_cast<std::vector<double>>(solution.at("cost_trajectory"));
+    auto iterations = std::any_cast<int>(solution.at("iterations"));
+    auto converged = std::any_cast<bool>(solution.at("converged"));
+    auto solve_time = std::any_cast<long long>(solution.at("solve_time"));
 
     // Create directory for plots if it doesn't exist
     const std::string plotDirectory = "../results/tests";
@@ -164,10 +166,10 @@ int main() {
 
     // Print optimization statistics
     std::cout << "\nOptimization Results:" << std::endl;
-    std::cout << "Iterations: " << solution.iterations << std::endl;
-    std::cout << "Final cost: " << solution.cost_sequence.back() << std::endl;
-    std::cout << "Converged: " << (solution.converged ? "Yes" : "No") << std::endl;
-    std::cout << "Solve time: " << solution.solve_time << " microseconds" << std::endl;
+    std::cout << "Iterations: " << iterations << std::endl;
+    std::cout << "Final cost: " << cost_sequence.back() << std::endl;
+    std::cout << "Converged: " << (converged ? "Yes" : "No") << std::endl;
+    std::cout << "Solve time: " << solve_time << " microseconds" << std::endl;
 
     return 0;
 }

--- a/examples/cddp_pendulum.cpp
+++ b/examples/cddp_pendulum.cpp
@@ -38,8 +38,6 @@ int main() {
     double length = 0.5;
     double damping = 0.01;
     std::string integration_type = "euler";
-    std::unique_ptr<cddp::DynamicalSystem> system =
-        std::make_unique<cddp::Pendulum>(timestep, length, mass, damping, integration_type);
     
     // Cost matrices
     Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(state_dim, state_dim);
@@ -52,8 +50,6 @@ int main() {
     goal_state << 0.0, 0.0;  // Upright position with zero velocity
     
     std::vector<Eigen::VectorXd> empty_reference_states;
-    auto objective = std::make_unique<cddp::QuadraticObjective>(
-        Q, R, Qf, goal_state, empty_reference_states, timestep);
     
     // Initial state (pendulum pointing down)
     Eigen::VectorXd initial_state(state_dim);
@@ -73,26 +69,32 @@ int main() {
     }
     J += objective->terminal_cost(X_init[horizon]);
     
-    // Create and configure the CDDP solver
-    cddp::CDDP cddp_solver(initial_state, goal_state, horizon, timestep);
-    cddp_solver.setDynamicalSystem(std::move(system));
-    cddp_solver.setObjective(std::move(objective));
-    
     // Control constraints
     Eigen::VectorXd control_lower_bound(control_dim);
     control_lower_bound << -100.0;
     Eigen::VectorXd control_upper_bound(control_dim);
     control_upper_bound << 100.0;
-    cddp_solver.addConstraint("ControlBoxConstraint",
-        std::make_unique<cddp::ControlBoxConstraint>(control_lower_bound, control_upper_bound));
     
     // Solver options
     cddp::CDDPOptions options;
     options.max_iterations = 20;
-    options.cost_tolerance = 1e-3;
-    options.regularization_type = "none";
-    options.regularization_control = 1e-7;
-    cddp_solver.setOptions(options);
+    options.tolerance = 1e-4;
+    options.acceptable_tolerance = 1e-5;
+    options.regularization.initial_value = 1e-7;
+    
+    // Create and configure the CDDP solver with new API
+    cddp::CDDP cddp_solver(
+        initial_state,
+        goal_state,
+        horizon,
+        timestep,
+        std::make_unique<cddp::Pendulum>(timestep, length, mass, damping, integration_type),
+        std::make_unique<cddp::QuadraticObjective>(Q, R, Qf, goal_state, empty_reference_states, timestep),
+        options
+    );
+    
+    cddp_solver.addPathConstraint("ControlBoxConstraint",
+        std::make_unique<cddp::ControlBoxConstraint>(control_lower_bound, control_upper_bound));
     
     // Set initial trajectory for the solver
     std::vector<Eigen::VectorXd> X(horizon + 1, Eigen::VectorXd::Zero(state_dim));
@@ -103,9 +105,9 @@ int main() {
     cddp_solver.setInitialTrajectory(X, U);
     
     // Solve the optimal control problem
-    cddp::CDDPSolution solution = cddp_solver.solve();
-    auto X_sol = solution.state_sequence;
-    auto U_sol = solution.control_sequence;
+    cddp::CDDPSolution solution = cddp_solver.solve(cddp::SolverType::IPDDP);
+    auto X_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("state_trajectory"));
+    auto U_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("control_trajectory"));
     
     // Create plot directory if it doesn't exist
     const std::string plotDirectory = "../results/tests";

--- a/examples/cddp_quadrotor_point.cpp
+++ b/examples/cddp_quadrotor_point.cpp
@@ -163,26 +163,24 @@ int main()
     Eigen::VectorXd initial_state = Eigen::VectorXd::Zero(state_dim);
     initial_state(3) = 1.0; // Identity quaternion: qw = 1
 
-    // Create the CDDP solver
-    cddp::CDDP cddp_solver(initial_state, goal_state, horizon, timestep);
-    cddp_solver.setDynamicalSystem(std::move(system));
-    cddp_solver.setObjective(std::move(objective));
+    // Solver options
+    cddp::CDDPOptions options;
+    options.max_iterations = 2000;
+    options.line_search.max_iterations = 15;
+    options.regularization.type = "control";
+    options.regularization.control = 1e-4;
+
+    // Create the CDDP solver with new API
+    cddp::CDDP cddp_solver(initial_state, goal_state, horizon, timestep,
+                          std::move(system), std::move(objective), options);
 
     // Control constraints (motor thrust limits)
     double min_force = 0.0; // Motors can only produce thrust upward
     double max_force = 5.0; // Maximum thrust per motor
     Eigen::VectorXd control_lower_bound = min_force * Eigen::VectorXd::Ones(control_dim);
     Eigen::VectorXd control_upper_bound = max_force * Eigen::VectorXd::Ones(control_dim);
-    cddp_solver.addConstraint("ControlConstraint",
-                              std::make_unique<cddp::ControlConstraint>(control_upper_bound));
-
-    // Solver options
-    cddp::CDDPOptions options;
-    options.max_iterations = 2000;
-    options.max_line_search_iterations = 15;
-    options.regularization_type = "control";
-    options.regularization_control = 1e-4;
-    cddp_solver.setOptions(options);
+    cddp_solver.addPathConstraint("ControlConstraint",
+                                  std::make_unique<cddp::ControlConstraint>(control_upper_bound));
 
     // Initial trajectory: allocate state and control trajectories
     std::vector<Eigen::VectorXd> X(horizon + 1, Eigen::VectorXd::Zero(state_dim));
@@ -202,10 +200,10 @@ int main()
     cddp_solver.setInitialTrajectory(X, U);
 
     // Solve the optimal control problem
-    cddp::CDDPSolution solution = cddp_solver.solve("IPDDP");
-    auto X_sol = solution.state_sequence;
-    auto U_sol = solution.control_sequence;
-    auto t_sol = solution.time_sequence;
+    cddp::CDDPSolution solution = cddp_solver.solve(cddp::SolverType::IPDDP);
+    auto X_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("state_trajectory"));
+    auto U_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("control_trajectory"));
+    auto t_sol = std::any_cast<std::vector<double>>(solution.at("time_points"));
 
     std::cout << "Final state: " << X_sol.back().transpose() << std::endl;
 

--- a/examples/cddp_unicycle_safe_ipddp_v2.cpp
+++ b/examples/cddp_unicycle_safe_ipddp_v2.cpp
@@ -66,14 +66,14 @@ int main() {
     options.max_iterations = 1000;
     options.verbose = true;
     options.debug = false;
-    options.use_parallel = false;
+    options.enable_parallel = false;
     options.num_threads = 1;
-    options.cost_tolerance = 1e-5;
-    options.grad_tolerance = 1e-4;
-    options.regularization_type = "both";
-    options.regularization_control = 1e-2;
-    options.regularization_state = 1e-3;
-    options.barrier_coeff = 1e-1;
+    options.tolerance = 1e-5;
+    options.acceptable_tolerance = 1e-4;
+    options.regularization.type = "both";
+    options.regularization.control = 1e-2;
+    options.regularization.state = 1e-3;
+    options.ipddp.barrier.mu_initial = 1e-1;
 
     // Control constraint
     Eigen::VectorXd control_upper_bound(control_dim);
@@ -92,26 +92,22 @@ int main() {
         options
     );
 
-    // Set dynamical system & objective explicitly
-    cddp_solver.setDynamicalSystem(std::make_unique<cddp::Unicycle>(timestep, integration_type));
-    cddp_solver.setObjective(std::make_unique<cddp::QuadraticObjective>(
-        Q, R, Qf, goal_state, empty_reference_states, timestep
-    ));
+    // Solver with new API already set up with system and objective
 
     // Add constraints
-    cddp_solver.addConstraint("ControlConstraint",
+    cddp_solver.addPathConstraint("ControlConstraint",
         std::make_unique<cddp::ControlConstraint>(control_upper_bound));
 
     // First ball constraint
     double radius1 = 0.4;
     Eigen::Vector2d center1(1.0, 1.0);
-    cddp_solver.addConstraint("BallConstraint",
+    cddp_solver.addPathConstraint("BallConstraint",
         std::make_unique<cddp::BallConstraint>(radius1, center1));
 
     // Second ball constraint
     double radius2 = 0.4;
     Eigen::Vector2d center2(1.5, 2.5);
-    cddp_solver.addConstraint("BallConstraint2",
+    cddp_solver.addPathConstraint("BallConstraint2",
         std::make_unique<cddp::BallConstraint>(radius2, center2));
 
     // Initial trajectory guess
@@ -123,9 +119,9 @@ int main() {
     cddp_solver.setInitialTrajectory(X_sol, U_sol);
 
     // Solve
-    cddp::CDDPSolution solution = cddp_solver.solve("IPDDP");
-    X_sol = solution.state_sequence; 
-    U_sol = solution.control_sequence;
+    cddp::CDDPSolution solution = cddp_solver.solve(cddp::SolverType::IPDDP);
+    X_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("state_trajectory")); 
+    U_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("control_trajectory"));
 
     // -------------------------------------------------
     // 3. Prepare Data for Plotting

--- a/examples/cddp_unicycle_safe_ipddp_v3.cpp
+++ b/examples/cddp_unicycle_safe_ipddp_v3.cpp
@@ -66,14 +66,14 @@ int main() {
     options.max_iterations = 1000;
     options.verbose = true;
     options.debug = false;
-    options.use_parallel = false;
+    options.enable_parallel = false;
     options.num_threads = 1;
-    options.cost_tolerance = 1e-5;
-    options.grad_tolerance = 1e-4;
-    options.regularization_type = "both";
-    options.regularization_control = 1e-2;
-    options.regularization_state = 1e-3;
-    options.barrier_coeff = 1e-1;
+    options.tolerance = 1e-5;
+    options.acceptable_tolerance = 1e-4;
+    options.regularization.type = "both";
+    options.regularization.control = 1e-2;
+    options.regularization.state = 1e-3;
+    options.ipddp.barrier.mu_initial = 1e-1;
 
     // Control constraint
     Eigen::VectorXd control_upper_bound(control_dim);
@@ -92,27 +92,23 @@ int main() {
         options
     );
 
-    // Set dynamical system & objective explicitly
-    cddp_solver.setDynamicalSystem(std::make_unique<cddp::Unicycle>(timestep, integration_type));
-    cddp_solver.setObjective(std::make_unique<cddp::QuadraticObjective>(
-        Q, R, Qf, goal_state, empty_reference_states, timestep
-    ));
+    // Solver with new API already set up with system and objective
 
     // Add constraints
     // Control constraint
-    cddp_solver.addConstraint("ControlConstraint",
+    cddp_solver.addPathConstraint("ControlConstraint",
         std::make_unique<cddp::ControlConstraint>(control_upper_bound));
 
     // First ball constraint
     double radius1 = 0.4;
     Eigen::Vector2d center1(1.0, 1.0);
-    cddp_solver.addConstraint("BallConstraint1",
+    cddp_solver.addPathConstraint("BallConstraint1",
         std::make_unique<cddp::BallConstraint>(radius1, center1));
 
     // Second ball constraint
     double radius2 = 0.4;
     Eigen::Vector2d center2(1.5, 2.5);
-    cddp_solver.addConstraint("BallConstraint2",
+    cddp_solver.addPathConstraint("BallConstraint2",
         std::make_unique<cddp::BallConstraint>(radius2, center2));
 
     // Linear constraint: y <= 1.0x + 0.5
@@ -120,7 +116,7 @@ int main() {
     A << -1.0, 1.0, 0.0;
     Eigen::VectorXd b(1);
     b << 0.5;
-    cddp_solver.addConstraint("LinearConstraint",
+    cddp_solver.addPathConstraint("LinearConstraint",
         std::make_unique<cddp::LinearConstraint>(A, b));
 
     // Initial trajectory guess
@@ -132,9 +128,9 @@ int main() {
     cddp_solver.setInitialTrajectory(X_sol, U_sol);
 
     // Solve
-    cddp::CDDPSolution solution = cddp_solver.solve("IPDDP");
-    X_sol = solution.state_sequence;
-    U_sol = solution.control_sequence;
+    cddp::CDDPSolution solution = cddp_solver.solve(cddp::SolverType::IPDDP);
+    X_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("state_trajectory"));
+    U_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("control_trajectory"));
 
     // Add this line to check the actual starting state in the solution
     std::cout << "Actual starting state in solution: " << X_sol[0].transpose() << std::endl;


### PR DESCRIPTION
Updates all CDDP example files to use the new modular solver architecture:

- Replace old constructor + setter pattern with integrated constructor
- Update solver selection from strings to SolverType enum  
- Change addConstraint to addPathConstraint
- Update solution access to std::any_cast pattern
- Modernize CDDPOptions parameter names

Ensures all examples work with the new API introduced in #129.