### PR TITLE
Fix LDLT solver caching bug

### DIFF
--- a/src/cddp_core/ipddp_solver.cpp
+++ b/src/cddp_core/ipddp_solver.cpp
@@ -1151,13 +1151,14 @@ namespace cddp
         Q_uu.diagonal().array() += context.regularization_;
 
         // Use cached LDLT solver or compute new factorization
-        if (!workspace_.ldlt_valid[t] || workspace_.ldlt_solvers[t].matrixLDLT().rows() != control_dim) {
+        bool need_recompute = !workspace_.ldlt_valid[t] || 
+                             (workspace_.ldlt_valid[t] && workspace_.ldlt_solvers[t].matrixLDLT().rows() != control_dim);
+        
+        if (need_recompute) {
           workspace_.ldlt_solvers[t].compute(Q_uu);
           workspace_.ldlt_valid[t] = true;
-        } else {
-          // Reuse existing factorization structure
-          workspace_.ldlt_solvers[t].compute(Q_uu);
         }
+        // If valid and correct size, reuse existing factorization without recomputing
         
         if (workspace_.ldlt_solvers[t].info() != Eigen::Success)
         {

--- a/src/cddp_core/msipddp_solver.cpp
+++ b/src/cddp_core/msipddp_solver.cpp
@@ -1448,13 +1448,14 @@ namespace cddp
         Q_uu.diagonal().array() += context.regularization_;
 
         // Use cached LDLT solver or compute new factorization
-        if (!workspace_.ldlt_valid[t] || workspace_.ldlt_solvers[t].matrixLDLT().rows() != control_dim) {
+        bool need_recompute = !workspace_.ldlt_valid[t] || 
+                             (workspace_.ldlt_valid[t] && workspace_.ldlt_solvers[t].matrixLDLT().rows() != control_dim);
+        
+        if (need_recompute) {
           workspace_.ldlt_solvers[t].compute(Q_uu);
           workspace_.ldlt_valid[t] = true;
-        } else {
-          // Reuse existing factorization structure
-          workspace_.ldlt_solvers[t].compute(Q_uu);
         }
+        // If valid and correct size, reuse existing factorization without recomputing
         
         if (workspace_.ldlt_solvers[t].info() != Eigen::Success)
         {


### PR DESCRIPTION
Fix LDLT solver caching in `IPDDPSolver` and `MSIPDDPSolver` to prevent runtime errors and ensure effective reuse of factorizations.