### PR TITLE
Fix Windows build dependency and directory issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,12 +52,14 @@ jobs:
       run: |
         choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
         choco install eigen -y
+        # Dependencies for matplotplusplus
+        choco install gnuplot -y
 
     - name: Build on Windows
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        mkdir build
+        mkdir -Force build
         cd build
         cmake ..
         cmake --build . --config Release


### PR DESCRIPTION
Add `gnuplot` dependency and use `mkdir -Force` for Windows build to fix build failures.