### PR TITLE
Fix macOS cmake installation conflict in GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,9 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         # Basic dependencies
-        brew install eigen cmake
+        brew install eigen || true
+        brew uninstall --ignore-dependencies cmake || true
+        brew install cmake
         
         # Dependencies for matplotplusplus
         brew install gnuplot


### PR DESCRIPTION
## Summary
- Fix cmake installation error on macOS in GitHub Actions CI
- Resolves conflict between different homebrew taps

## Problem
The macOS CI was failing with:
```
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
```

## Solution
- Uninstall any existing cmake installation before reinstalling
- Use `--ignore-dependencies` flag to avoid removing dependent packages
- Add `|| true` to ensure workflow continues even if commands fail

## Test plan
- [ ] Verify GitHub Actions CI passes on macOS
- [ ] Confirm build still works on Ubuntu (Docker)